### PR TITLE
fix parsing of command line

### DIFF
--- a/cli.js
+++ b/cli.js
@@ -5,7 +5,7 @@ const chokidar = require('chokidar');
 if (argv._) {
   let myself = argv._.indexOf(__filename);
   if (myself == -1) {
-    myself = argv._.findIndex(a => a.indexOf('.bin/vuei18n-po') != -1);
+    myself = argv._.findIndex(a => a.indexOf('bin/vuei18n-po') != -1);
   }
   if (myself != -1 && myself + 1 < argv._.length) {
     argv.po = argv._.slice(myself + 1);


### PR DESCRIPTION
When the tool is being run in `node` Docker image, argv._ looks  like following:
["/usr/local/bin/node","/usr/local/bin/vuei18n-po","ru_RU/LC_MESSAGES/messages.po"]

So "." in the search for "myself" leads to completely wrong parsing and, at the end of the day, confusing message about "parsing plurals"



Steps to reproduce:

```
docker run --rm -it node:18 bash

npm install -g vuei18n-po

touch qq.po

vuei18n-po qq.po
```

Expected result: file `qq.po` should be parsed (attempted)
Actual result: `/usr/local/bin/vuei18n-po` file is being parsed (and failing)

If one adds `console.log(args.po)` to `cli.js`, you'll see: `[ '/usr/local/bin/node', '/usr/local/bin/vuei18n-po', 'qq.po' ]`